### PR TITLE
Created a hydra_train_model.py and config set-up

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -81,6 +81,7 @@ pygments==2.17.2 ; python_version >= '3.7'
 pygtrie==2.5.0
 pyparsing==3.1.1 ; python_full_version >= '3.6.8'
 python-dateutil==2.8.2 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+pytorch-lightning==2.1.3
 pyyaml==6.0.1
 requests==2.31.0 ; python_version >= '3.7'
 rich==13.7.0 ; python_full_version >= '3.7.0'
@@ -108,6 +109,7 @@ tzdata==2023.4 ; python_version >= '2'
 urllib3==2.1.0 ; python_version >= '3.8'
 vine==5.1.0 ; python_version >= '3.6'
 voluptuous==0.14.1 ; python_version >= '3.7'
+wandb==0.16.1
 wcwidth==0.2.12
 yarl==1.9.4 ; python_version >= '3.7'
 zc.lockfile==3.0.post1 ; python_version >= '3.7'

--- a/src/configs/default_config.yaml
+++ b/src/configs/default_config.yaml
@@ -1,0 +1,2 @@
+defaults:
+    - experiment: exp1

--- a/src/configs/experiment/exp1.yaml
+++ b/src/configs/experiment/exp1.yaml
@@ -1,0 +1,25 @@
+seed: 47
+
+model_name: efficientnet_es.ra_in1k
+pretrained: True
+lr_encoder: 3e-6
+lr_head: 3e-4
+
+optimizer: AdamW
+criterion: cross_entropy
+
+batch_size: 32
+num_workers: 4
+num_epochs: 100
+num_classes: 525
+drop_rate: 0.5
+resize_dims: [224, 224]
+augmentation_strategy: moderate
+
+log_every_n_steps: 10
+wandb_run_name: exp1_training_run
+wandb_project_name: mlops-bird-classification
+
+train_dir: data/raw/train
+val_dir: data/raw/validation
+file_name: model

--- a/src/hydra_train_model.py
+++ b/src/hydra_train_model.py
@@ -1,0 +1,90 @@
+from typing import Any, Dict
+
+import hydra
+from hydra.utils import to_absolute_path
+import yaml
+from omegaconf import DictConfig, OmegaConf
+from pytorch_lightning import Trainer, seed_everything
+from pytorch_lightning.callbacks import ModelCheckpoint
+from pytorch_lightning.loggers import WandbLogger
+
+from data.data import ImageFolderClassificationModule
+from models.model import ImageClassifier
+
+
+
+def load_yaml_config(filepath: str) -> Dict[str, Any]:
+    """
+    Function to load config from YAML file.
+    
+    :param filepath: Path to the YAML file.
+    :return: Dictionary with the loaded configuration.
+    """
+    with open(filepath, 'r') as file:
+        return yaml.safe_load(file)
+
+
+@hydra.main(config_path="configs", config_name="default_config.yaml", version_base="1.1")
+def train(config: DictConfig) -> None:
+    """
+    Train a model using the provided configuration.
+
+    :param config: Configuration object provided by Hydra.
+    """
+    # Load model and hyperparameter configs
+    print(f"Configuration: \n {OmegaConf.to_yaml(config)}")
+    hparams = config.experiment
+    seed_everything(hparams["seed"], workers=True)
+
+    # Load normalization parameters
+    data_config = load_yaml_config(to_absolute_path("data/train_data_config.yaml"))
+    normalization_mean = data_config['mean']
+    normalization_std = data_config['std']
+
+    # Set up data module
+    data_module = ImageFolderClassificationModule(
+        train_dir = to_absolute_path(hparams["train_dir"]), 
+        val_dir = to_absolute_path(hparams["val_dir"]),
+        resize_dims = tuple(hparams["resize_dims"]), 
+        normalization_mean = normalization_mean, 
+        normalization_std = normalization_std,
+        augmentation_strategy = hparams["augmentation_strategy"],
+        batch_size = hparams["batch_size"],
+        num_workers = hparams["num_workers"],
+    )
+    data_module.setup()
+
+    # Create the model
+    model = ImageClassifier(
+        model_name=hparams["model_name"],
+        num_classes=hparams["num_classes"],
+        drop_rate=hparams["drop_rate"],
+        pretrained=hparams["pretrained"],
+        lr_encoder=hparams["lr_encoder"],
+        lr_head=hparams["lr_head"],
+        optimizer=hparams["optimizer"],
+        criterion=hparams["criterion"],
+    )
+
+    # Create a PyTorch Lightning trainer
+    trainer = Trainer(
+        max_epochs=hparams["num_epochs"],
+        logger=WandbLogger(name=hparams["wandb_run_name"], project=hparams["wandb_project_name"]),
+        log_every_n_steps=hparams["log_every_n_steps"],
+        callbacks=[ModelCheckpoint(
+            dirpath="checkpoints/",
+            filename=hparams["file_name"] + '-{epoch:02d}-{val_accuracy:.2f}',
+            save_top_k=1,
+            monitor="val_accuracy",
+            mode="max"
+        )],
+        accelerator="auto"
+    )
+
+    # Start training
+    trainer.fit(model, data_module.train_dataloader(), data_module.val_dataloader())
+
+if __name__ == "__main__":
+    train()
+
+    # To run file with specified config: python src/hydra_train_model.py experiment=exp1


### PR DESCRIPTION
By running the hydra_train_model.py with a specified config file containing wandb, model and hyper parameters, a model is trained and the dvc pulled data and logged in wandb.

Use command:
python src/hydra_train_model.py experiment=exp1